### PR TITLE
ci: deploy on tagging not push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,9 @@ on:
       - 'v*'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Changed deployment trigger from push to main branch to version tags

- Added workflow_dispatch for manual deployment triggering

- Specified explicit read-only permissions for workflow security


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Push to main branch"] -->|removed| B["Deploy trigger"]
  C["Version tags v*"] -->|added| B
  D["Manual workflow_dispatch"] -->|added| B
  E["Workflow permissions"] -->|added| F["contents: read"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deploy.yml</strong><dd><code>Update deployment trigger to version tags</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/deploy.yml

<ul><li>Modified trigger condition from <code>push.branches.main</code> to <code>push.tags</code> <br>matching <code>v*</code> pattern<br> <li> Added <code>workflow_dispatch</code> event for manual deployment execution<br> <li> Added explicit <code>permissions</code> section with <code>contents: read</code> for improved <br>security</ul>


</details>


  </td>
  <td><a href="https://github.com/Rindrics/izuminokami-kanesada/pull/9/files#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

