### PR TITLE
ci: add Firebase preview deploy workflow for PRs

### DIFF
--- a/.github/workflows/firebase-preview.yml
+++ b/.github/workflows/firebase-preview.yml
@@ -1,0 +1,43 @@
+name: Firebase Preview Deploy
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Deploy to Firebase Hosting Preview Channel
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+          projectId: izuminokami-kanesada
+          expires: 7d


### PR DESCRIPTION
### **User description**
- resolve #12


___

### **PR Type**
Enhancement


___

### **Description**
- Add GitHub Actions workflow for Firebase preview deployments

- Deploy to Firebase Hosting preview channel on pull requests

- Configure automatic cleanup after 7 days expiration

- Set up Node.js and pnpm environment for builds


___

### Diagram Walkthrough


```mermaid
flowchart LR
  PR["Pull Request to main"] -- "Trigger workflow" --> Checkout["Checkout code"]
  Checkout -- "Setup environment" --> Setup["Setup pnpm & Node.js"]
  Setup -- "Install & build" --> Build["Build project"]
  Build -- "Deploy preview" --> Firebase["Firebase Hosting Preview Channel"]
  Firebase -- "Expires in 7d" --> Cleanup["Auto cleanup"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>firebase-preview.yml</strong><dd><code>Firebase preview deployment workflow configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/firebase-preview.yml

<ul><li>Create new GitHub Actions workflow triggered on pull requests to main <br>branch<br> <li> Configure job to checkout code, setup pnpm v10 and Node.js v20<br> <li> Install dependencies with frozen lockfile and build the project<br> <li> Deploy to Firebase Hosting preview channel with 7-day expiration<br> <li> Set appropriate permissions for contents read, pull-requests write, <br>and checks write</ul>


</details>


  </td>
  <td><a href="https://github.com/Rindrics/izuminokami-kanesada/pull/13/files#diff-0c82121a73427cd22d7fa70d1079d11e21bb569c117fb62cb35cd50966005f8e">+43/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

