### PR TITLE
ci: add Firebase preview deploy workflow for PRs

### DIFF
--- a/.github/workflows/firebase-preview.yml
+++ b/.github/workflows/firebase-preview.yml
@@ -1,0 +1,43 @@
+name: Firebase Preview Deploy
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Deploy to Firebase Hosting Preview Channel
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+          projectId: izuminokami-kanesada
+          expires: 7d


### PR DESCRIPTION
### **User description**
- resolve #12


___

### **PR Type**
Enhancement


___

### **Description**
- Add Firebase preview deployment workflow for pull requests

- Automatically builds and deploys to Firebase Hosting preview channel

- Preview deployments expire after 7 days

- Includes Node.js and pnpm setup with dependency caching


___

### Diagram Walkthrough


```mermaid
flowchart LR
  PR["Pull Request to main"] -- "triggers" --> WF["Firebase Preview Workflow"]
  WF -- "checkout code" --> CO["Code"]
  CO -- "setup environment" --> ENV["pnpm + Node.js"]
  ENV -- "install & build" --> BUILD["Build artifacts"]
  BUILD -- "deploy" --> PREVIEW["Firebase Preview Channel"]
  PREVIEW -- "expires in 7d" --> EXPIRE["Cleanup"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>firebase-preview.yml</strong><dd><code>Firebase preview deployment workflow configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/firebase-preview.yml

<ul><li>New GitHub Actions workflow triggered on pull requests to main branch<br> <li> Sets up pnpm (v10) and Node.js (v20) with dependency caching<br> <li> Builds the project using pnpm build command<br> <li> Deploys to Firebase Hosting preview channel with 7-day expiration<br> <li> Uses Firebase service account credentials from repository secrets</ul>


</details>


  </td>
  <td><a href="https://github.com/Rindrics/izuminokami-kanesada/pull/15/files#diff-0c82121a73427cd22d7fa70d1079d11e21bb569c117fb62cb35cd50966005f8e">+43/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

