### PR TITLE
fix: remove unnecessary semicolon from master text

### DIFF
--- a/src/data/sample-contents.ts
+++ b/src/data/sample-contents.ts
@@ -48,7 +48,7 @@ export const sampleContents: Content[] = [
     book_id: 'lunyu',
     section: '学而第一',
     chapter: '2',
-    text: '有子曰 其為人也孝弟 而好犯上者 鮮矣; 不-好犯上 而好作亂者 未之有也; 君子務本 本立而道生; 孝弟也者 其為仁之本與',
+    text: '有子曰 其為人也孝弟 而好犯上者 鮮矣 不-好犯上 而好作亂者 未之有也 君子務本 本立而道生 孝弟也者 其為仁之本與',
     segments: [
       { text: '有子曰', start_pos: 0, end_pos: 3, speaker: null },
       {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Remove unnecessary semicolons from Chinese text content

- Semicolons replaced with spaces in Lunyu section 1.2


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Chinese text with semicolons"] -- "remove semicolons" --> B["Chinese text with spaces"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sample-contents.ts</strong><dd><code>Remove semicolons from Lunyu text content</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/data/sample-contents.ts

<ul><li>Removed semicolons from the <code>text</code> field in Lunyu section 1.2 <br>(content_id: 'lunyu/1/2')<br> <li> Replaced four semicolons with spaces to match proper Chinese <br>punctuation formatting<br> <li> Text now reads: '有子曰 其為人也孝弟 而好犯上者 鮮矣 不-好犯上 而好作亂者 未之有也 君子務本 本立而道生 孝弟也者 <br>其為仁之本與'</ul>


</details>


  </td>
  <td><a href="https://github.com/Rindrics/izuminokami-kanesada/pull/28/files#diff-fb8c88dbebe9a0ed3f8c385f9630c5f70b810fef6f1e6a04f2714eca77c3cd18">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected sample content text formatting for improved readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->