### PR TITLE
feat: publish audio bucket

### DIFF
--- a/adr/0020-audio-delivery-without-cdn.md
+++ b/adr/0020-audio-delivery-without-cdn.md
@@ -2,7 +2,7 @@
 
 ## ステータス
 
-採用
+採用（2026-01-24 更新: 署名付き URL → 公開 URL に変更）
 
 ## コンテキスト
 
@@ -22,7 +22,9 @@
 
 ## 決定
 
-**現時点では Cloud CDN を使用せず、署名付き URL による直接配信を採用する。**
+**現時点では Cloud CDN を使用せず、公開バケットによる直接配信を採用する。**
+
+~~当初は署名付き URL による配信を検討したが、Next.js が `output: 'export'`（静的サイト生成）のため API Routes が使用できず、署名付き URL の生成ができない。そのため、バケットを公開設定にして直接アクセスを許可する方式に変更した。~~
 
 ## 根拠
 
@@ -40,19 +42,22 @@ Cloud CDN を使用するには Global Load Balancer が必須であり、最低
 
 | 方式 | 月額コスト |
 |------|-----------|
-| GCS + 署名付き URL | ~$0.12 |
+| GCS + 公開 URL | ~$0.12 |
 | GCS + Cloud CDN + LB | ~$25 |
 
 個人プロジェクトで月間数十 GB 以上の配信が見込めない現状では、CDN の導入は費用対効果が低い。
 
 ### セキュリティ面
 
-署名付き URL により以下のセキュリティ要件を満たしている：
+公開バケット方式のリスクと対策：
 
-- URL は有効期限付き（15 分）
-- URL を知っていても期限切れで無効化
-- バケットは非公開（`allUsers` なし）
-- API 経由でのみ署名付き URL を取得可能
+| リスク | 対策 |
+|--------|------|
+| 不正な大量ダウンロード | GCS のリクエスト上限設定、監視アラート |
+| コスト増大 | 予算アラートの設定 |
+| コンテンツの無断利用 | 音声は TTS 生成のため著作権リスクは限定的 |
+
+現時点ではユーザー数が限定的であり、上記リスクは許容範囲内と判断。
 
 ### パフォーマンス面
 
@@ -65,7 +70,20 @@ Cloud CDN を使用するには Global Load Balancer が必須であり、最低
 ### 現在の構成
 
 ```text
-ユーザー → Next.js API → 署名付き URL 生成 → GCS 直接アクセス
+ユーザー → GCS 公開 URL → 音声ファイル
+```
+
+URL 形式: `https://storage.googleapis.com/{bucket}/audio/{book}/{section}/{chapter}-{lang}.mp3`
+
+### Terraform 設定
+
+```hcl
+# バケットを公開設定
+resource "google_storage_bucket_iam_member" "public_read" {
+  bucket = google_storage_bucket.audio.name
+  role   = "roles/storage.objectViewer"
+  member = "allUsers"
+}
 ```
 
 ### 将来の移行パス
@@ -75,11 +93,12 @@ Cloud CDN を使用するには Global Load Balancer が必須であり、最低
 1. 月間配信量が 50GB を超える
 2. レイテンシが問題になる（海外ユーザーの増加）
 3. DDoS 攻撃を受ける
+4. 不正な大量ダウンロードが発生する
 
 移行時の変更点：
 - Terraform で Load Balancer + CDN を追加
 - バックエンドバケットとして GCS を設定
-- 署名付き URL → CDN URL に切り替え
+- 公開 URL → CDN URL に切り替え
 
 ## 代替案
 
@@ -94,6 +113,10 @@ Cloud CDN を使用するには Global Load Balancer が必須であり、最低
 ### C: 外部 CDN（Cloudflare など）
 
 **将来の検討候補**: 無料プランあり、ただし GCS との統合に追加設定が必要
+
+### D: 署名付き URL
+
+**却下理由**: Next.js が `output: 'export'` のため API Routes が使用できず、署名付き URL の生成ができない。Cloud Functions などで API を別途作成する方法もあるが、現時点では過剰な複雑さ。
 
 ## 関連
 

--- a/terraform/modules/audio-storage/main.tf
+++ b/terraform/modules/audio-storage/main.tf
@@ -30,8 +30,13 @@ resource "google_storage_bucket" "audio" {
   }
 }
 
-# Note: No public access - use signed URLs instead
-# This prevents unauthorized bulk downloads and reduces cost risk
+# Grant public read access for audio playback
+# This allows direct access to audio files without signed URLs
+resource "google_storage_bucket_iam_member" "public_read" {
+  bucket = google_storage_bucket.audio.name
+  role   = "roles/storage.objectViewer"
+  member = "allUsers"
+}
 
 # Grant service account upload-only access (least privilege)
 resource "google_storage_bucket_iam_member" "service_account_write" {


### PR DESCRIPTION
### **User description**
- doing #40


___

### **PR Type**
Enhancement


___

### **Description**
- Changed audio delivery from signed URLs to public bucket access

- Updated ADR-0020 to document the new public URL approach

- Added Terraform configuration to grant public read access

- Documented rationale: Next.js static export prevents API Routes usage

- Added security risk mitigation strategies for public bucket


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Previous: Signed URLs"] -->|"API Routes unavailable"| B["Issue: Next.js static export"]
  B -->|"Decision"| C["Public Bucket Access"]
  C -->|"Terraform IAM"| D["allUsers objectViewer role"]
  D -->|"Result"| E["Direct GCS public URL"]
  E -->|"Risk mitigation"| F["Request limits + monitoring"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>0020-audio-delivery-without-cdn.md</strong><dd><code>Document shift to public bucket audio delivery strategy</code>&nbsp; &nbsp; </dd></summary>
<hr>

adr/0020-audio-delivery-without-cdn.md

<ul><li>Updated status to reflect change from signed URLs to public URLs<br> <li> Changed decision from signed URL delivery to public bucket delivery<br> <li> Replaced security section with risk/mitigation table for public access<br> <li> Updated cost comparison table to reflect public URL approach<br> <li> Added explanation for why signed URLs were rejected (Next.js static <br>export limitation)<br> <li> Updated architecture diagram to show direct GCS public URL access<br> <li> Added Terraform configuration example for public bucket setup<br> <li> Added new migration trigger for unauthorized bulk downloads</ul>


</details>


  </td>
  <td><a href="https://github.com/Rindrics/izuminokami-kanesada/pull/56/files#diff-8c76b837d3048a5f2bff8d8a8b2654b258f84651473aa5e13b3106557c9099c0">+33/-10</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Enable public read access for audio bucket</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

terraform/modules/audio-storage/main.tf

<ul><li>Added <code>google_storage_bucket_iam_member</code> resource to grant public read <br>access<br> <li> Changed comment from "No public access" to "Grant public read access"<br> <li> Configured <code>allUsers</code> member with <code>storage.objectViewer</code> role<br> <li> Updated rationale comment to reflect direct access without signed URLs</ul>


</details>


  </td>
  <td><a href="https://github.com/Rindrics/izuminokami-kanesada/pull/56/files#diff-a198c8674da995f9748addf63c70e015580f37c1ceb243e86d30550dc63f8b6a">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

