### PR TITLE
feat: show implicit speaker change with dashes (e.g., ― 孔子 ―)

### DIFF
--- a/src/components/HakubunWithTabs.tsx
+++ b/src/components/HakubunWithTabs.tsx
@@ -482,9 +482,9 @@ export function HakubunWithTabs({ segments }: Props) {
                   {...wrapperProps}
                 >
                   {/* Show implicit speaker name (no indent) */}
-                  {isImplicitSpeakerChange && group.speaker && (
+                  {isImplicitSpeakerChange && (
                     <span className="block -ml-4 text-zinc-300 dark:text-zinc-600">
-                      ― {getPersonName(group.speaker)} ―
+                      ― {getPersonName(group.speaker!)} ―
                     </span>
                   )}
                   {group.segments.map((segment, segIndex) => (


### PR DESCRIPTION
### **User description**
- resolve #72


___

### **PR Type**
Enhancement


___

### **Description**
- Display speaker name with dashes when speaker changes implicitly

- Add indent for speech following implicit speaker changes

- Import `getPersonName` utility for speaker name resolution


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Detect implicit speaker change"] --> B["Add indent to speech"]
  A --> C["Display speaker name with dashes"]
  B --> D["Improved text formatting"]
  C --> D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HakubunWithTabs.tsx</strong><dd><code>Implicit speaker change detection and display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/HakubunWithTabs.tsx

<ul><li>Import <code>getPersonName</code> function from persons data<br> <li> Add logic to detect implicit speaker changes between consecutive <br>groups<br> <li> Apply indentation when speech follows implicit speaker change<br> <li> Render speaker name with decorative dashes above indented speech</ul>


</details>


  </td>
  <td><a href="https://github.com/Rindrics/izuminokami-kanesada/pull/73/files#diff-784aef302bc2f3b20477246747e6dd07b0442875938d5314d51f5a5513b6232e">+20/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced dialogue display with improved speaker change detection and labeling. Speaker labels now appear inline when speaker transitions occur without narration, with adjusted indentation for better visual clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->