### PR TITLE
fix: redefine daxue sections

### DIFF
--- a/contents/books.yaml
+++ b/contents/books.yaml
@@ -1,6 +1,7 @@
 - id: lunyu
   name: 論語
   compositionYear: -479 # 孔子没後、弟子たちが編纂
+  sectionLabel: 篇
   totalSections: 20
   sections:
     - id: '1'
@@ -67,6 +68,7 @@
 - id: mengzi
   name: 孟子
   compositionYear: -300 # 孟子の弟子たちが編纂
+  sectionLabel: 篇
   totalSections: 14
   sections:
     - id: '1'
@@ -115,6 +117,7 @@
 - id: daxue
   name: 大学
   compositionYear: -450 # 曾子の作とされる
+  sectionLabel: 章
   totalSections: 6
   sections:
     - id: '1'
@@ -139,6 +142,7 @@
 - id: zhongyong
   name: 中庸
   compositionYear: -430 # 子思の作とされる
+  sectionLabel: 章
   totalSections: 19
   sections:
     - id: '1'
@@ -203,6 +207,7 @@
 
 - id: yijing
   name: 易経
+  sectionLabel: 経
   totalSections: 2
   sections:
     - id: '1'
@@ -214,6 +219,7 @@
 
 - id: shujing
   name: 書経
+  sectionLabel: 篇
   totalSections: 4
   sections:
     - id: '1'
@@ -231,6 +237,7 @@
 
 - id: shijing
   name: 詩経
+  sectionLabel: 篇
   totalSections: 4
   sections:
     - id: '1'
@@ -248,6 +255,7 @@
 
 - id: liji
   name: 礼記
+  sectionLabel: 篇
   totalSections: 1
   sections:
     - id: '1'
@@ -256,6 +264,7 @@
 
 - id: chunqiu
   name: 春秋左氏伝
+  sectionLabel: 篇
   totalSections: 12
   sections:
     - id: '1'

--- a/contents/books.yaml
+++ b/contents/books.yaml
@@ -115,11 +115,26 @@
 - id: daxue
   name: 大学
   compositionYear: -450 # 曾子の作とされる
-  totalSections: 1
+  totalSections: 6
   sections:
     - id: '1'
-      name: 大学
-      totalChapters: 11
+      name: 第一章
+      totalChapters: 3
+    - id: '2'
+      name: 第二章
+      totalChapters: 4
+    - id: '3'
+      name: 第三章
+      totalChapters: 1
+    - id: '4'
+      name: 第四章
+      totalChapters: 1
+    - id: '5'
+      name: 第五章
+      totalChapters: 2
+    - id: '6'
+      name: 第六章
+      totalChapters: 4
 
 - id: zhongyong
   name: 中庸

--- a/contents/books.yaml
+++ b/contents/books.yaml
@@ -139,11 +139,65 @@
 - id: zhongyong
   name: 中庸
   compositionYear: -430 # 子思の作とされる
-  totalSections: 1
+  totalSections: 19
   sections:
     - id: '1'
-      name: 中庸
-      totalChapters: 33
+      name: 第一章
+      totalChapters: 1
+    - id: '2'
+      name: 第二章
+      totalChapters: 1
+    - id: '3'
+      name: 第三章
+      totalChapters: 1
+    - id: '4'
+      name: 第四章
+      totalChapters: 1
+    - id: '5'
+      name: 第五章
+      totalChapters: 1
+    - id: '6'
+      name: 第六章
+      totalChapters: 1
+    - id: '7'
+      name: 第七章
+      totalChapters: 1
+    - id: '8'
+      name: 第八章
+      totalChapters: 1
+    - id: '9'
+      name: 第九章
+      totalChapters: 1
+    - id: '10'
+      name: 第十章
+      totalChapters: 1
+    - id: '11'
+      name: 第十一章
+      totalChapters: 1
+    - id: '12'
+      name: 第十二章
+      totalChapters: 1
+    - id: '13'
+      name: 第十三章
+      totalChapters: 1
+    - id: '14'
+      name: 第十四章
+      totalChapters: 1
+    - id: '15'
+      name: 第十五章
+      totalChapters: 1
+    - id: '16'
+      name: 第十六章
+      totalChapters: 1
+    - id: '17'
+      name: 第十七章
+      totalChapters: 1
+    - id: '18'
+      name: 第十八章
+      totalChapters: 1
+    - id: '19'
+      name: 第十九章
+      totalChapters: 1
 
 # 五経
 

--- a/scripts/generate-contents.ts
+++ b/scripts/generate-contents.ts
@@ -78,6 +78,7 @@ interface InputBook {
   id: string;
   name: string;
   compositionYear?: number;
+  sectionLabel?: string;
   totalSections: number;
   sections: InputSection[];
 }
@@ -102,6 +103,7 @@ interface OutputBook {
   id: string;
   name: string;
   compositionYear?: number;
+  sectionLabel?: string;
   totalSections: number;
   sections: OutputSection[];
 }
@@ -1345,6 +1347,7 @@ export function getAdjacentContentIds(
     id: book.id,
     name: book.name,
     compositionYear: book.compositionYear,
+    sectionLabel: book.sectionLabel,
     totalSections: book.totalSections,
     sections: book.sections.map((section) => ({
       id: section.id,

--- a/src/app/books/[bookId]/[sectionId]/page.tsx
+++ b/src/app/books/[bookId]/[sectionId]/page.tsx
@@ -33,11 +33,12 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const section = getSectionById(bookId, sectionId);
 
   if (!book || !section) {
-    return { title: '編が見つかりません' };
+    return { title: 'セクションが見つかりません' };
   }
 
+  const sectionLabel = book.sectionLabel ?? '編';
   const title = `${section.name} - ${book.name}`;
-  const description = `${book.name} ${section.name}の全章を一覧表示。現在${section.chapters.length}/${section.totalChapters}章を収録。孔子の教えを白文と訓読みで学習できます。`;
+  const description = `${book.name} ${section.name}の全章を一覧表示。現在${section.chapters.length}/${section.totalChapters}章を収録。白文と訓読みで学習できます。`;
 
   return createMetadata({
     title,
@@ -63,8 +64,13 @@ export default async function SectionPage({ params }: Props) {
   const prevUrl = prevSection ? `/books/${bookId}/${prev}` : null;
   const nextUrl = nextSection ? `/books/${bookId}/${next}` : null;
 
-  const prevLabel = prevSection ? `前の編（${prevSection.name}）へ` : undefined;
-  const nextLabel = nextSection ? `次の編（${nextSection.name}）へ` : undefined;
+  const sectionLabel = book.sectionLabel ?? '編';
+  const prevLabel = prevSection
+    ? `前の${sectionLabel}（${prevSection.name}）へ`
+    : undefined;
+  const nextLabel = nextSection
+    ? `次の${sectionLabel}（${nextSection.name}）へ`
+    : undefined;
 
   return (
     <PageWithSidebar showSidebar={false}>

--- a/src/app/books/[bookId]/page.tsx
+++ b/src/app/books/[bookId]/page.tsx
@@ -27,6 +27,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     return { title: '書籍が見つかりません' };
   }
 
+  const sectionLabel = book.sectionLabel ?? '編';
   const currentSections = book.sections.filter(
     (s) => s.chapters.length > 0,
   ).length;
@@ -36,7 +37,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   );
 
   const title = book.name;
-  const description = `${book.name}の全編を一覧表示。現在${currentSections}/${book.totalSections}編、計${currentChapters}章を収録。白文・訓読み・読み下し文で学習できます。`;
+  const description = `${book.name}の全${sectionLabel}を一覧表示。現在${currentSections}/${book.totalSections}${sectionLabel}、計${currentChapters}章を収録。白文・訓読み・読み下し文で学習できます。`;
 
   return createMetadata({
     title,
@@ -116,7 +117,7 @@ export default async function BookPage({ params }: Props) {
 
       <section>
         <h2 className="mb-4 text-lg font-medium text-zinc-600 dark:text-zinc-400">
-          編一覧
+          {book.sectionLabel ?? '編'}一覧
         </h2>
         <ListWithFavoriteSidebar>
           <ul className="space-y-2">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -51,14 +51,15 @@ export default function Home() {
               );
               const hasContent = currentChapters > 0;
               const isSingleSection = book.totalSections === 1;
+              const sectionLabel = book.sectionLabel ?? '編';
 
               const progressText = isSingleSection
                 ? `${currentChapters}/${totalChapters}章`
-                : `${currentSections}/${book.totalSections}編、計${currentChapters}章`;
+                : `${currentSections}/${book.totalSections}${sectionLabel}、計${currentChapters}章`;
 
               const disabledText = isSingleSection
                 ? `0/${totalChapters}章`
-                : `0/${book.totalSections}編`;
+                : `0/${book.totalSections}${sectionLabel}`;
 
               return (
                 <li key={book.id}>

--- a/src/types/book.ts
+++ b/src/types/book.ts
@@ -4,6 +4,7 @@ export interface Book {
   id: string; // "lunyu"
   name: string; // "論語"
   compositionYear?: number; // Year of composition (negative for BCE, e.g., -479)
+  sectionLabel?: string; // Display label for sections (e.g., "編", "章", "篇")
   totalSections: number; // Total number of sections in the book (e.g., 20 for Lunyu)
   sections: Section[];
 }


### PR DESCRIPTION
- doing #90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customizable section labels for classical texts (篇, 章, 経).
  * Expanded hierarchical organization with more granular chapter breakdowns for select texts.

* **Improvements**
  * Navigation labels now dynamically adapt to different section types instead of using fixed terminology.
  * Updated UI headers and descriptions to reflect section-specific naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->