### PR TITLE
Release for v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v0.7.0](https://github.com/Rindrics/izuminokami-kanesada/compare/v0.6.0...v0.7.0) - 2026-02-13
+- feat: provide copy button by @Rindrics in https://github.com/Rindrics/izuminokami-kanesada/pull/126
+- fix: improve appearance of prev/next button by @Rindrics in https://github.com/Rindrics/izuminokami-kanesada/pull/131
+- feat: provide collection functionality by @Rindrics in https://github.com/Rindrics/izuminokami-kanesada/pull/128
+- feat: add lunyu contents by @Rindrics in https://github.com/Rindrics/izuminokami-kanesada/pull/130
+- fix: redefine daxue sections by @Rindrics in https://github.com/Rindrics/izuminokami-kanesada/pull/133
+- fix: remove changelog about unreleased tag by @Rindrics in https://github.com/Rindrics/izuminokami-kanesada/pull/135
+
 ## [v0.6.0](https://github.com/Rindrics/izuminokami-kanesada/compare/v0.5.0...v0.6.0) - 2026-02-06
 - feat: improve nav UI by @Rindrics in https://github.com/Rindrics/izuminokami-kanesada/pull/120
 - feat(mcp): improve content generation workflow with MCP by @Rindrics in https://github.com/Rindrics/izuminokami-kanesada/pull/122


### PR DESCRIPTION
This pull request is for the next release as v0.7.0 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.7.0 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.6.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* feat: provide copy button by @Rindrics in https://github.com/Rindrics/izuminokami-kanesada/pull/126
* fix: improve appearance of prev/next button by @Rindrics in https://github.com/Rindrics/izuminokami-kanesada/pull/131
* feat: provide collection functionality by @Rindrics in https://github.com/Rindrics/izuminokami-kanesada/pull/128
* feat: add lunyu contents by @Rindrics in https://github.com/Rindrics/izuminokami-kanesada/pull/130
* fix: redefine daxue sections by @Rindrics in https://github.com/Rindrics/izuminokami-kanesada/pull/133
* fix: remove changelog about unreleased tag by @Rindrics in https://github.com/Rindrics/izuminokami-kanesada/pull/135


**Full Changelog**: https://github.com/Rindrics/izuminokami-kanesada/compare/v0.6.0...tagpr-from-v0.6.0