### PR TITLE
fix: stop audio on navigation

### DIFF
--- a/models/AudioPlayer.tla
+++ b/models/AudioPlayer.tla
@@ -156,6 +156,13 @@ PlaySingleSegment(seg) ==
     /\ currentSegment' = seg
     /\ loopEnabled' = TRUE
 
+\* アンマウント (ページ遷移時のクリーンアップ)
+\* どの状態からでも発生し、再生を強制停止する
+Unmount ==
+    /\ playState' = "stopped"
+    /\ currentSegment' = 0
+    /\ UNCHANGED <<loopEnabled, selectedSegments>>
+
 -----------------------------------------------------------------------------
 (* 状態遷移 *)
 Next ==
@@ -167,6 +174,7 @@ Next ==
     \/ SelectAll
     \/ SelectNone
     \/ \E seg \in Segments : PlaySingleSegment(seg)
+    \/ Unmount
 
 -----------------------------------------------------------------------------
 (* 時間的性質 *)


### PR DESCRIPTION
- resolve #136

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Player now reliably stops playback and resets current position when the component is unmounted, releasing audio resources and timers.

* **New Features**
  * Added an explicit unmount/cleanup path integrated into normal playback flow.
  * Added lifecycle guards to prevent resume/play attempts after unmount and to safely cancel pending resume timers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->