### PR TITLE
Release for v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.7.1](https://github.com/Rindrics/izuminokami-kanesada/compare/v0.7.0...v0.7.1) - 2026-03-08
+- fix: stop audio on navigation by @Rindrics in https://github.com/Rindrics/izuminokami-kanesada/pull/137
+- Fix Japanese translations for clarity and accuracy by @Rindrics in https://github.com/Rindrics/izuminokami-kanesada/pull/140
+
 ## [v0.7.0](https://github.com/Rindrics/izuminokami-kanesada/compare/v0.6.0...v0.7.0) - 2026-02-13
 - feat: provide copy button by @Rindrics in https://github.com/Rindrics/izuminokami-kanesada/pull/126
 - fix: improve appearance of prev/next button by @Rindrics in https://github.com/Rindrics/izuminokami-kanesada/pull/131

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "izuminokami-kanesada",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "四書五経およびその他の中国古典を学習するためのWebアプリケーション",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
This pull request is for the next release as v0.7.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.7.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.7.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* fix: stop audio on navigation by @Rindrics in https://github.com/Rindrics/izuminokami-kanesada/pull/137
* Fix Japanese translations for clarity and accuracy by @Rindrics in https://github.com/Rindrics/izuminokami-kanesada/pull/140


**Full Changelog**: https://github.com/Rindrics/izuminokami-kanesada/compare/v0.7.0...tagpr-from-v0.7.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audio continuing to play when navigating between pages
  * Improved Japanese translation clarity and accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->