### PR TITLE
feat: add content for 大学1-2

### DIFF
--- a/audio-manifest.json
+++ b/audio-manifest.json
@@ -69,6 +69,108 @@
       }
     ]
   },
+  "daxue/1/2": {
+    "segments": [
+      {
+        "index": 0,
+        "zh": {
+          "hash": "ac9d840d57367acca1f4caf73e3e9fe95158a5914fba6275b544de883c2abbba",
+          "uploadedAt": "2026-03-19T00:46:48.389Z"
+        }
+      },
+      {
+        "index": 1,
+        "zh": {
+          "hash": "c968677e84832a34d0c85becfbd53865787659b151784ef0a15ccb6592a4d016",
+          "uploadedAt": "2026-03-19T00:46:48.556Z"
+        }
+      },
+      {
+        "index": 2,
+        "zh": {
+          "hash": "bc63f642ebe8485caef353c4f6f5041a7c2a1f9a5558b7a6a175c20954f7734f",
+          "uploadedAt": "2026-03-19T00:46:48.714Z"
+        }
+      },
+      {
+        "index": 3,
+        "zh": {
+          "hash": "64ffbc2bd06131a78c760713726782329ca7ca4e850e7deaa7f63f04396f4c16",
+          "uploadedAt": "2026-03-19T00:46:48.869Z"
+        }
+      },
+      {
+        "index": 4,
+        "zh": {
+          "hash": "59c74e827f7293f0b286f1d6a05198086ebe08a5544870d1e2e6bece16bced3d",
+          "uploadedAt": "2026-03-19T00:46:49.033Z"
+        }
+      },
+      {
+        "index": 5,
+        "zh": {
+          "hash": "13ffb00d1642d058fb901b155fce646821376ecff19282cafad738407986e2e4",
+          "uploadedAt": "2026-03-19T00:46:49.192Z"
+        }
+      },
+      {
+        "index": 6,
+        "zh": {
+          "hash": "6d4db32ebc7d0c31f4da030dc547ef9a0a0e34f9d99e28aa8c1ec00d92e850b5",
+          "uploadedAt": "2026-03-19T00:46:49.396Z"
+        }
+      },
+      {
+        "index": 7,
+        "zh": {
+          "hash": "3fe68bfcdd58b7c5a1c55bffcc6762c79f73a0992b29308530ef3da0a1ab3e52",
+          "uploadedAt": "2026-03-19T00:46:49.562Z"
+        }
+      },
+      {
+        "index": 8,
+        "zh": {
+          "hash": "e038f2bdc4aa36ba866f83a6589ad9db73986e0cfa572be04efba44e605144ea",
+          "uploadedAt": "2026-03-19T00:46:49.724Z"
+        }
+      },
+      {
+        "index": 9,
+        "zh": {
+          "hash": "74c4556f0bc9fbdbc1036eea7c7e6e8bdd567f1e4d40996add81593d44cf91b0",
+          "uploadedAt": "2026-03-19T00:46:49.868Z"
+        }
+      },
+      {
+        "index": 10,
+        "zh": {
+          "hash": "17273a0a272a80e6f6c45160b173dc7acdcaa8637c149ae65e7a4dad700aabcf",
+          "uploadedAt": "2026-03-19T00:46:50.030Z"
+        }
+      },
+      {
+        "index": 11,
+        "zh": {
+          "hash": "2ff64904758a433007abb92fe49b48676b404658578bb677df76cff33a434b90",
+          "uploadedAt": "2026-03-19T00:46:50.221Z"
+        }
+      },
+      {
+        "index": 12,
+        "zh": {
+          "hash": "bbe39f81f8c33823decd2d31f7752eb4334aae75a46a563ac92361c65e6bda24",
+          "uploadedAt": "2026-03-19T00:46:50.578Z"
+        }
+      },
+      {
+        "index": 13,
+        "zh": {
+          "hash": "874ddb4b6fb121ce01e53f7d13d577a1c2c62e2361928afc0dabfa67789eb7e2",
+          "uploadedAt": "2026-03-19T00:46:50.987Z"
+        }
+      }
+    ]
+  },
   "lunyu/1/1": {
     "segments": [
       {

--- a/contents/input/daxue/1/2.yaml
+++ b/contents/input/daxue/1/2.yaml
@@ -1,0 +1,58 @@
+segments:
+  - text:
+      original: 古之欲明明德於天下者 先治其國
+      japanese: 古の明徳を天下に明らかにせんと欲する者は、先（ま）づ其の国を治む。
+    speaker: null
+  - text:
+      original: 欲治其國者 先齊其家
+      japanese: 其の国を治めんと欲する者は、先（ま）づ其の家を齊う。
+    speaker: null
+  - text:
+      original: 欲齊其家者 先修其身
+      japanese: 其の家を齊えんと欲する者は、先（ま）づ其の身を修む。
+    speaker: null
+  - text:
+      original: 欲修其身者 先正其心
+      japanese: 其の身を修めんと欲する者は、先（ま）づ其の心を正す。
+    speaker: null
+  - text:
+      original: 欲正其心者 先誠其意
+      japanese: 其の心を正さんと欲する者は、先（ま）づ其の意を誠にす。
+    speaker: null
+  - text:
+      original: 欲誠其意者 先致其知
+      japanese: 其の意を誠にせんと欲する者は、先（ま）づ其の知（ち）を致（きわ）む。
+    speaker: null
+  - text:
+      original: 致知在格物
+      japanese: 知（ち）を致（きわ）むるは物に格（いた）るに在り。
+    speaker: null
+  - text:
+      original: 物格而后知至
+      japanese: 物格（いた）りて后、知（ち）至（きわ）まる。
+    speaker: null
+  - text:
+      original: 知至而后意誠
+      japanese: 知至（きわ）まりて后、意誠なり。
+    speaker: null
+  - text:
+      original: 意誠而后心正
+      japanese: 意誠にして后、心正し。
+    speaker: null
+  - text:
+      original: 心正而后身修
+      japanese: 心正しくして后、身修まる。
+    speaker: null
+  - text:
+      original: 身修而后家齊
+      japanese: 身修まりて后、家齊う。
+    speaker: null
+  - text:
+      original: 家齊而后國治
+      japanese: 家齊いて后、国治まる。
+    speaker: null
+  - text:
+      original: 國治而后天下平
+      japanese: 国治まりて后、天下平かなり。
+    speaker: null
+pinyin_reviewed: true

--- a/src/data/hanzi-dictionary.ts
+++ b/src/data/hanzi-dictionary.ts
@@ -7749,6 +7749,62 @@ export const hanziDictionary: HanziEntry[] = [
     ],
     is_common: true,
   },
+  {
+    id: '治',
+    meanings: [
+      {
+        id: '治-zhì',
+        onyomi: 'ジ',
+        pinyin: 'zhì',
+        tone: 4,
+        meaning_ja: '治める、治まる',
+        is_default: true,
+      },
+    ],
+    is_common: true,
+  },
+  {
+    id: '平',
+    meanings: [
+      {
+        id: '平-píng',
+        onyomi: 'ヘイ',
+        pinyin: 'píng',
+        tone: 2,
+        meaning_ja: '平ら、太平',
+        is_default: true,
+      },
+    ],
+    is_common: true,
+  },
+  {
+    id: '誠',
+    meanings: [
+      {
+        id: '誠-chéng',
+        onyomi: 'セイ',
+        pinyin: 'chéng',
+        tone: 2,
+        meaning_ja: 'まこと',
+        is_default: true,
+      },
+    ],
+    is_common: true,
+  },
+  {
+    id: '意',
+    meanings: [
+      {
+        id: '意-yì',
+        onyomi: 'イ',
+        pinyin: 'yì',
+        tone: 4,
+        meaning_ja: '心、意',
+        is_default: true,
+      },
+    ],
+    is_common: true,
+  },
 ];
 
 const hanziMap = new Map(hanziDictionary.map((e) => [e.id, e]));

--- a/src/data/kunyomi-dictionary.ts
+++ b/src/data/kunyomi-dictionary.ts
@@ -3144,6 +3144,26 @@ export const kunyomiDictionary: KunyomiEntry[] = [
     text: '任',
     readings: [{ id: '任-まか', ruby: 'まか', is_default: true }],
   },
+  {
+    id: '治',
+    text: '治',
+    readings: [{ id: '治-おさ', ruby: 'おさ', is_default: true }],
+  },
+  {
+    id: '平',
+    text: '平',
+    readings: [{ id: '平-たいら', ruby: 'たいら', is_default: true }],
+  },
+  {
+    id: '意',
+    text: '意',
+    readings: [{ id: '意-い', ruby: 'い', is_default: true }],
+  },
+  {
+    id: '誠',
+    text: '誠',
+    readings: [{ id: '誠-まこと', ruby: 'まこと', is_default: true }],
+  },
 ];
 
 export function getKunyomiEntry(text: string): KunyomiEntry | undefined {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new audio content manifest entry with 14 segments
  * Expanded hanzi dictionary with four new character entries (治, 平, 誠, 意) featuring Japanese translations and pronunciation data
  * Extended kanji reading database for improved character coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->